### PR TITLE
Add permissions to component Brute Force Stop Administration

### DIFF
--- a/access.xml
+++ b/access.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<access component="com_bfstop">
+    <section name="component">
+        <action name="core.admin" title="JACTION_ADMIN" description="JACTION_ADMIN_COMPONENT_DESC"/>
+        <action name="core.manage" title="JACTION_MANAGE" description="JACTION_MANAGE_COMPONENT_DESC"/>
+    </section>
+</access>

--- a/config.xml
+++ b/config.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<config>
+    <fieldset
+            name="permissions"
+            label="JCONFIG_PERMISSIONS_LABEL"
+            description="JCONFIG_PERMISSIONS_DESC"
+            >
+
+        <field
+                name="rules"
+                type="rules"
+                label="JCONFIG_PERMISSIONS_LABEL"
+                class="inputbox"
+                filter="rules"
+                component="com_bfstop"
+                section="component"/>
+    </fieldset>
+</config>


### PR DESCRIPTION
This will allow to deny or add permissions to access to component in Administration side.
After uploading this 2 files to your site, goto YOURSITE/administrator/index.php?option=com_config&view=component&component=com_bfstop

2 options will appear:
- Configure ACL & Options
- Access Administration Interface